### PR TITLE
Added protocol EnvironmentRepresentable

### DIFF
--- a/EnvSelectionDemo/EnvSelectionDemo/AppDelegate.swift
+++ b/EnvSelectionDemo/EnvSelectionDemo/AppDelegate.swift
@@ -8,26 +8,55 @@
 
 import UIKit
 
-enum Envs: String, CaseIterable {
+enum Envs: String, CaseIterable, EnvironmentRepresentable {
     case production = "https://production.server.com/"
     case staging = "https://staging.server.com/"
     case development = "https://development.server.com"
     case testing = "https://10.0.1.1/"
     case edge = "edge.server.com"
+    
+    var environmentTitle: String {
+        return rawValue
+    }
 }
 
-var ACTIVE_ENVIRONMENT = Envs.production.rawValue
+enum NonStringEnvs: Int, CaseIterable, EnvironmentRepresentable {
+    case production
+    case staging
+    case development
+    case testing
+    case edge
+    
+    static let endpoints = [
+        "https://production.server.com/",
+        "https://staging.server.com/",
+        "https://development.server.com",
+        "https://10.0.1.1/",
+        "edge.server.com"
+    ]
+    
+    var endpoint: String {
+        guard rawValue < NonStringEnvs.endpoints.count else { return "" }
+        return NonStringEnvs.endpoints[rawValue]
+    }
+    
+    var environmentTitle: String {
+        return endpoint
+    }
+}
+
+var ACTIVE_ENVIRONMENT = NonStringEnvs.production.environmentTitle
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-
+    
     var window: UIWindow?
-
-
+    
+    
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        let envChanger = EnvironmentChangerController(envs: Envs.self, buttonImage: UIImage(named: "AppIcon")) { selectedEnvironment in
-            ACTIVE_ENVIRONMENT = selectedEnvironment.rawValue
+        let envChanger = EnvironmentChangerController(envs: NonStringEnvs.self, buttonImage: UIImage(named: "AppIcon")) { selectedEnvironment in
+            ACTIVE_ENVIRONMENT = selectedEnvironment.environmentTitle
             print(ACTIVE_ENVIRONMENT)
         }
         
@@ -35,29 +64,29 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         return true
     }
-
+    
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
     }
-
+    
     func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
-
+    
     func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
     }
-
+    
     func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
-
+    
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
-
+    
+    
 }
 

--- a/EnvSelectionDemo/EnvSelectionDemo/EnvironmentChangerController.swift
+++ b/EnvSelectionDemo/EnvSelectionDemo/EnvironmentChangerController.swift
@@ -2,7 +2,6 @@
 //  EnvironmentChanger.swift
 //  Created by Teodor Marinov on 1.07.19.
 //
-import Foundation
 import UIKit
 
 private class EnvironmentChangerWindow: UIWindow {
@@ -24,7 +23,16 @@ private class EnvironmentChangerWindow: UIWindow {
     }
 }
 
-class EnvironmentChangerController<T>: UIViewController where T: RawRepresentable, T.RawValue == String, T: CaseIterable {
+/// Protocol defining the needed behaviour of the `Envs` enum.
+/// Each enum case should provide `String` representing the environment title.
+public protocol EnvironmentRepresentable {
+    
+    //This string is later on used for persisting the selected enviornment.
+    /// `String` representing the environment title.
+    var environmentTitle: String { get }
+}
+
+class EnvironmentChangerController<T>: UIViewController where T: EnvironmentRepresentable, T: CaseIterable {
     class EnvAlertAction: UIAlertAction {
         var selectedEnv: T?
     }
@@ -81,7 +89,7 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
     ///     to avoid having inaccurate button image and size.
     func resizeFrame(newWidth: CGFloat, newHeight: CGFloat) {
         let imageEdgeInsets = (newWidth + newHeight) / 2
-
+        
         button.frame.width = newWidth
         button.frame.height = newHeight
         button.imageEdgeInsets = UIEdgeInsets(top: imageEdgeInsets, left: imageEdgeInsets, bottom: imageEdgeInsets, right: imageEdgeInsets)
@@ -90,10 +98,10 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
     /// When initializing the controller with the given environments,
     /// saves the first found environment from the list to UserDefaults.
     private func saveFirstEnvironment() {
-        guard let firstEnvironment = envs.allCases.first?.rawValue else { return }
+        guard let firstEnvironment = envs.allCases.first else { return }
         
         if getSavedEnvironment() == "" {
-            UserDefaults.standard.set(firstEnvironment, forKey: ACTIVE_ENV_KEY)
+            UserDefaults.standard.set(firstEnvironment.environmentTitle, forKey: ACTIVE_ENV_KEY)
         }
     }
     
@@ -146,9 +154,9 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
     private func actionHandler(sender: UIAlertAction) {
         guard let envAlertAction = sender as? EnvAlertAction,
             let selectedEnv = envAlertAction.selectedEnv else { return }
-        UserDefaults.standard.set(selectedEnv.rawValue, forKey: ACTIVE_ENV_KEY)
+        UserDefaults.standard.set(selectedEnv.environmentTitle, forKey: ACTIVE_ENV_KEY)
         
-        let alert = UIAlertController(title: "Environment changed successfully.", message: "Please restart the app to access \(selectedEnv.rawValue)", preferredStyle: .alert)
+        let alert = UIAlertController(title: "Environment changed successfully.", message: "Please restart the app to access \(selectedEnv.environmentTitle)", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         
         completionHandler(selectedEnv)
@@ -168,7 +176,7 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
         let alert = UIAlertController(title: "Current env: \(getSavedEnvironment())", message: "Please select a backend environment", preferredStyle: .actionSheet)
         
         envs.allCases.forEach {
-            let alertAction = EnvAlertAction(title: $0.rawValue, style: .default, handler: actionHandler(sender:))
+            let alertAction = EnvAlertAction(title: $0.environmentTitle, style: .default, handler: actionHandler(sender:))
             alertAction.selectedEnv = $0
             alert.addAction(alertAction)
         }

--- a/EnvironmentChanger.swift
+++ b/EnvironmentChanger.swift
@@ -2,7 +2,6 @@
 //  EnvironmentChanger.swift
 //  Created by Teodor Marinov on 1.07.19.
 //
-import Foundation
 import UIKit
 
 private class EnvironmentChangerWindow: UIWindow {
@@ -24,7 +23,16 @@ private class EnvironmentChangerWindow: UIWindow {
     }
 }
 
-class EnvironmentChangerController<T>: UIViewController where T: RawRepresentable, T.RawValue == String, T: CaseIterable {
+/// Protocol defining the needed behaviour of the `Envs` enum.
+/// Each enum case should provide `String` representing the environment title.
+public protocol EnvironmentRepresentable {
+    
+    //This string is later on used for persisting the selected enviornment.
+    /// `String` representing the environment title.
+    var environmentTitle: String { get }
+}
+
+class EnvironmentChangerController<T>: UIViewController where T: EnvironmentRepresentable, T: CaseIterable {
     class EnvAlertAction: UIAlertAction {
         var selectedEnv: T?
     }
@@ -81,7 +89,7 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
     ///     to avoid having inaccurate button image and size.
     func resizeFrame(newWidth: CGFloat, newHeight: CGFloat) {
         let imageEdgeInsets = (newWidth + newHeight) / 2
-
+        
         button.frame.width = newWidth
         button.frame.height = newHeight
         button.imageEdgeInsets = UIEdgeInsets(top: imageEdgeInsets, left: imageEdgeInsets, bottom: imageEdgeInsets, right: imageEdgeInsets)
@@ -90,10 +98,10 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
     /// When initializing the controller with the given environments,
     /// saves the first found environment from the list to UserDefaults.
     private func saveFirstEnvironment() {
-        guard let firstEnvironment = envs.allCases.first?.rawValue else { return }
+        guard let firstEnvironment = envs.allCases.first else { return }
         
         if getSavedEnvironment() == "" {
-            UserDefaults.standard.set(firstEnvironment, forKey: ACTIVE_ENV_KEY)
+            UserDefaults.standard.set(firstEnvironment.environmentTitle, forKey: ACTIVE_ENV_KEY)
         }
     }
     
@@ -146,9 +154,9 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
     private func actionHandler(sender: UIAlertAction) {
         guard let envAlertAction = sender as? EnvAlertAction,
             let selectedEnv = envAlertAction.selectedEnv else { return }
-        UserDefaults.standard.set(selectedEnv.rawValue, forKey: ACTIVE_ENV_KEY)
+        UserDefaults.standard.set(selectedEnv.environmentTitle, forKey: ACTIVE_ENV_KEY)
         
-        let alert = UIAlertController(title: "Environment changed successfully.", message: "Please restart the app to access \(selectedEnv.rawValue)", preferredStyle: .alert)
+        let alert = UIAlertController(title: "Environment changed successfully.", message: "Please restart the app to access \(selectedEnv.environmentTitle)", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         
         completionHandler(selectedEnv)
@@ -168,7 +176,7 @@ class EnvironmentChangerController<T>: UIViewController where T: RawRepresentabl
         let alert = UIAlertController(title: "Current env: \(getSavedEnvironment())", message: "Please select a backend environment", preferredStyle: .actionSheet)
         
         envs.allCases.forEach {
-            let alertAction = EnvAlertAction(title: $0.rawValue, style: .default, handler: actionHandler(sender:))
+            let alertAction = EnvAlertAction(title: $0.environmentTitle, style: .default, handler: actionHandler(sender:))
             alertAction.selectedEnv = $0
             alert.addAction(alertAction)
         }


### PR DESCRIPTION
Added protocol EnvironmentRepresentable to define behaviour for the Envs enum on integrator's project. The env changer no longer relies on String RawValue, thus the user has more flexibility on the Envs enum. Added NonStringEnvs to the demo project. Code refactored to use "environmentTitle" instead of "rawValue".